### PR TITLE
docs: close code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,3 +35,4 @@ cp .env.example .env
 
 # Start development server
 npx expo start
+```


### PR DESCRIPTION
## Summary
- fix missing closing code block in README getting started section

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ea641be20832f849df7c6a3b72ccd